### PR TITLE
Support different animationDurations for opening / closing cells

### DIFF
--- a/FoldingCell/FoldingCell/FoldingCell/FoldingCell.swift
+++ b/FoldingCell/FoldingCell/FoldingCell/FoldingCell.swift
@@ -310,7 +310,7 @@ open class FoldingCell: UITableViewCell {
   func durationSequence(_ type: AnimationType)-> [TimeInterval] {
     var durations  = [TimeInterval]()
     for index in 0..<itemCount-1 {
-      let duration = animationDuration(index, type: .open)
+      let duration = animationDuration(index, type: type)
       durations.append(TimeInterval(duration / 2.0))
       durations.append(TimeInterval(duration / 2.0))
     }


### PR DESCRIPTION
The FoldingCell has support for providing different animation timings depending on whether it is opening or closing but there's a bug.

override func animationDuration(_ itemIndex:NSInteger, type:AnimationType)-> TimeInterval

always gets called with the AnimationType .open


This corrects the bug where a hardcoded animation type is passed through.

