### PR TITLE
Remove force-unwrapped optional

### DIFF
--- a/FoldingCell/FoldingCell/FoldingCell/FoldingCell.swift
+++ b/FoldingCell/FoldingCell/FoldingCell/FoldingCell.swift
@@ -508,8 +508,8 @@ extension UIView {
   func pb_takeSnapshot(_ frame: CGRect) -> UIImage? {
     UIGraphicsBeginImageContextWithOptions(frame.size, false, 0.0)
     
-    let context = UIGraphicsGetCurrentContext();
-    context!.translateBy(x: frame.origin.x * -1, y: frame.origin.y * -1)
+    guard let context = UIGraphicsGetCurrentContext() else { return nil }
+    context.translateBy(x: frame.origin.x * -1, y: frame.origin.y * -1)
     
     guard let currentContext = UIGraphicsGetCurrentContext() else {
       return nil


### PR DESCRIPTION
Removed force-unwrapped optional causing a crash (found nil while
unwrapping optional) in pb_takeSnapshot ->
https://github.com/Ramotion/folding-cell/issues/89