### PR TITLE
Fix errors and warnings when migrating to swift 4

### DIFF
--- a/FoldingCell/FoldingCell.xcodeproj/project.pbxproj
+++ b/FoldingCell/FoldingCell.xcodeproj/project.pbxproj
@@ -614,7 +614,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -641,7 +641,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.ramotion.FoldingCell;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -777,6 +777,7 @@
 				9DAA51691EDDBAD700DFC539 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/FoldingCell/FoldingCell/FoldingCell.swift
+++ b/FoldingCell/FoldingCell/FoldingCell.swift
@@ -165,8 +165,8 @@ open class FoldingCell: UITableViewCell {
           multiplier: constraint.multiplier, constant: constraint.constant)
         
         newConstraints.append(newConstraint)
-      } else if let item: UIView = constraint.secondItem as? UIView , item == containerView {
-        let newConstraint = NSLayoutConstraint(item: constraint.firstItem, attribute: constraint.firstAttribute,
+      } else if let firstItem = constraint.firstItem as? UIView, let secondItem: UIView = constraint.secondItem as? UIView , secondItem == containerView {
+        let newConstraint = NSLayoutConstraint(item: firstItem, attribute: constraint.firstAttribute,
           relatedBy: constraint.relation, toItem: animationView, attribute: constraint.secondAttribute,
           multiplier: constraint.multiplier, constant: constraint.constant)
         
@@ -275,7 +275,7 @@ open class FoldingCell: UITableViewCell {
   ///   - value: unfold = true; collapse = false.
   ///   - animated: animate changes.
   ///   - completion: A block object to be executed when the animation sequence ends.
-  open func unfold(_ value: Bool, animated: Bool = true, completion: ((Void) -> Void)? = nil) {
+  open func unfold(_ value: Bool, animated: Bool = true, completion: (() -> Void)? = nil) {
     if animated {
       value ? openAnimation(completion) : closeAnimation(completion)
     } else {
@@ -292,7 +292,7 @@ open class FoldingCell: UITableViewCell {
    - parameter completion: A block object to be executed when the animation sequence ends.
    */
   @available(iOS, deprecated, message: "Use unfold(_:animated:completion) method instead.")
-  open func selectedAnimation(_ isSelected: Bool, animated: Bool, completion: ((Void) -> Void)?) {
+  open func selectedAnimation(_ isSelected: Bool, animated: Bool, completion: (() -> Void)?) {
     unfold(isSelected, animated: animated, completion: completion)
   }
   
@@ -320,7 +320,7 @@ open class FoldingCell: UITableViewCell {
     return durations
   }
   
-  func openAnimation(_ completion: ((Void) -> Void)?) {
+  func openAnimation(_ completion: (() -> Void)?) {
     isUnfolded = true
     removeImageItemsFromAnimationView()
     addImageItemsToAnimationView()
@@ -371,7 +371,7 @@ open class FoldingCell: UITableViewCell {
     }
   }
   
-  func closeAnimation(_ completion: ((Void) -> Void)?) {
+  func closeAnimation(_ completion: (() -> Void)?) {
     isUnfolded = false
     removeImageItemsFromAnimationView()
     addImageItemsToAnimationView()


### PR DESCRIPTION
- The error was `Missing argument for parameter #1 in call` which happened on `completion()` because of its declaration `((Void) -> Void)?`
```
When calling this function in Swift 4 or later, you must pass a '()' tuple; did you mean for the input type to be '()'?
Replace '(Void)' with '()'
```

- The warning was `Expression implicitly coerced from 'AnyObject?' to Any` at [line 169](https://github.com/Ramotion/folding-cell/compare/master...ohyes1h:master#diff-07a64a24c73a193a924ec57f587fb922L169)
Simply use if-let to solve this warning.