### PR TITLE
Add basic SwiftPM package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "FoldingCell",
+    // platforms: [.iOS("8.0")],
+    products: [
+        .library(name: "FoldingCell", targets: ["FoldingCell"])
+    ],
+    targets: [
+        .target(
+            name: "FoldingCell",
+            path: "FoldingCell/FoldingCell"
+        )
+    ]
+)


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.