### PR TITLE
Proposed an animation fix

### DIFF
--- a/FoldingCell/FoldingCell-Demo/TableViewController.swift
+++ b/FoldingCell/FoldingCell-Demo/TableViewController.swift
@@ -125,8 +125,10 @@ extension TableViewController {
             tableView.endUpdates()
             
             // fix https://github.com/Ramotion/folding-cell/issues/169
-            if cell.frame.maxY > tableView.frame.maxY {
-                tableView.scrollToRow(at: indexPath, at: UITableView.ScrollPosition.bottom, animated: true)
+            if cell.frame.minY < tableView.contentOffset.y {
+                tableView.scrollToRow(at: indexPath, at: .top, animated: true)
+            } else if cell.frame.maxY > tableView.frame.maxY + tableView.contentOffset.y {
+                tableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
             }
         }, completion: nil)
     }


### PR DESCRIPTION
### Summary

1. Fixed scroll-to-bottom condition so that both sides are relative y-coordinates. `cell.frame.maxY > tableView.frame.maxY` should be `cell.frame.maxY > tableView.frame.maxY + tableView.contentOffset.y`
2. Enabled scrolling to the top of the cell, when some of top part of this cell is across the upper edge of the table view (that is, hidden) and is tapped to unfold.

